### PR TITLE
pin clisops v0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 xarray>=0.15
 dask[complete]
 netcdf4
-git+https://github.com/roocs/clisops#egg=clisops
+git+https://github.com/roocs/clisops@v0.1.0#egg=clisops


### PR DESCRIPTION
This PR pins clisops to version v0.1.0.

See also: https://github.com/roocs/daops/issues/13