### PR TITLE
fix to allow time to be None

### DIFF
--- a/daops/utils/consolidate.py
+++ b/daops/utils/consolidate.py
@@ -41,16 +41,18 @@ def consolidate(collection, **kwargs):
             LOGGER.info(f"Testing {len(file_paths)} files in time range: ...")
             files_in_range = []
 
-            ds = xr.open_mfdataset(file_paths)
+            ds = xr.open_mfdataset(file_paths, use_cftime=True)
 
             if time['start_time'] is None:
                 time['start_time'] = ds.time.values.min().strftime("%Y")
             if time['end_time'] is None:
                 time['end_time'] = ds.time.values.max().strftime("%Y")
 
-            required_years = set(range(*[int(_.split('-')[0]) for _ in list(time.values())]))
+            times = [int(time['start_time'].split('-')[0]), int(time['end_time'].split('-')[0]) + 1]
+            required_years = set(range(*[_ for _ in times]))
 
             for i, fpath in enumerate(file_paths):
+
                 LOGGER.info(f"File {i}: {fpath}")
                 ds = xr.open_dataset(fpath)
 

--- a/daops/utils/consolidate.py
+++ b/daops/utils/consolidate.py
@@ -35,13 +35,20 @@ def consolidate(collection, **kwargs):
         consolidated = _consolidate_dset(dset)
 
         if "time" in kwargs:
-            time = kwargs["time"].tuple
-            # need int(_.split('-')[0]) if passing in more than year from TimeParameter
-            required_years = set(range(*[int(_.split('-')[0]) for _ in time]))
+            time = kwargs["time"].asdict()
 
             file_paths = glob.glob(consolidated)
             LOGGER.info(f"Testing {len(file_paths)} files in time range: ...")
             files_in_range = []
+
+            ds = xr.open_mfdataset(file_paths)
+
+            if time['start_time'] is None:
+                time['start_time'] = ds.time.values.min().strftime("%Y")
+            if time['end_time'] is None:
+                time['end_time'] = ds.time.values.max().strftime("%Y")
+
+            required_years = set(range(*[int(_.split('-')[0]) for _ in list(time.values())]))
 
             for i, fpath in enumerate(file_paths):
                 LOGGER.info(f"File {i}: {fpath}")

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -9,6 +9,7 @@ from roocs_utils.parameter import (
     area_parameter,
     time_parameter,
 )
+from daops import CONFIG
 
 CMIP5_IDS = [
     "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
@@ -176,3 +177,45 @@ def test_parameter_classes_as_args(tmpdir):
 
     ds_subset = xr.open_dataset(result.file_paths[0], use_cftime=True)
     assert ds_subset.tas.shape == (433, 1, 1)
+
+
+@pytest.mark.online
+def test_time_is_none(tmpdir):
+
+    result = subset(
+        CMIP5_IDS[1],
+        time=None,
+        area=("0", "-10", "120", "40"),
+        output_dir=tmpdir,
+        file_namer="simple"
+    )
+    _check_output_nc(result)
+
+    ds = xr.open_mfdataset(os.path.join(
+        CONFIG["project:cmip5"]["base_dir"], "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc"),
+        use_cftime=True)
+    ds_subset = xr.open_dataset(result.file_paths[0], use_cftime=True)
+
+    assert ds_subset.time.values.min().strftime("%Y-%m-%d") == ds.time.values.min().strftime("%Y-%m-%d")
+    assert ds_subset.time.values.max().strftime("%Y-%m-%d") == ds.time.values.max().strftime("%Y-%m-%d")
+
+
+@pytest.mark.online
+def test_start_time_is_none(tmpdir):
+
+    result = subset(
+        CMIP5_IDS[1],
+        time="/2120-12-16",
+        area=("0", "-10", "120", "40"),
+        output_dir=tmpdir,
+        file_namer="simple"
+    )
+    _check_output_nc(result)
+
+    ds = xr.open_mfdataset(os.path.join(
+        CONFIG["project:cmip5"]["base_dir"], "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc"),
+        use_cftime=True)
+    ds_subset = xr.open_dataset(result.file_paths[0], use_cftime=True)
+
+    assert ds_subset.time.values.min().strftime("%Y-%m-%d") == ds.time.values.min().strftime("%Y-%m-%d")
+    assert ds_subset.time.values.max().strftime("%Y-%m-%d") == "2120-12-16"

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -198,6 +198,27 @@ def test_time_is_none(tmpdir):
 
     assert ds_subset.time.values.min().strftime("%Y-%m-%d") == ds.time.values.min().strftime("%Y-%m-%d")
     assert ds_subset.time.values.max().strftime("%Y-%m-%d") == ds.time.values.max().strftime("%Y-%m-%d")
+    
+    
+@pytest.mark.online
+def test_end_time_is_none(tmpdir):
+
+    result = subset(
+        CMIP5_IDS[2],
+        time="1940-10-14/",
+        area=("0", "-10", "120", "40"),
+        output_dir=tmpdir,
+        file_namer="simple"
+    )
+    _check_output_nc(result)
+
+    ds = xr.open_mfdataset(os.path.join(
+        CONFIG["project:cmip5"]["base_dir"], "cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc"),
+        use_cftime=True)
+    ds_subset = xr.open_dataset(result.file_paths[0], use_cftime=True)
+
+    assert ds_subset.time.values.min().strftime("%Y-%m-%d") == '1940-10-16'
+    assert ds_subset.time.values.max().strftime("%Y-%m-%d") == ds.time.values.max().strftime("%Y-%m-%d")
 
 
 @pytest.mark.online


### PR DESCRIPTION
@agstephens @cehbrecht 

This fix allows `start time` and/or `end time` to be `None`. 

However, the test `test_time_is_none` is failing as the end time of the dataset is being cut off. I think this may be due to the `filter_times_within` function in `clisops` : https://github.com/roocs/clisops/blob/master/clisops/utils/output_utils.py#L45. But I can't see what to change to fix it. 