### PR TITLE
Test time invariant datasets

### DIFF
--- a/daops/utils/consolidate.py
+++ b/daops/utils/consolidate.py
@@ -68,6 +68,7 @@ def consolidate(collection, **kwargs):
             if len(files_in_range) == 0:
                 raise Exception(f"No files found in given time range for {dset}")
 
+        # catch where "time" attribute cannot be accessed in ds
         except AttributeError:
             pass
 

--- a/daops/utils/consolidate.py
+++ b/daops/utils/consolidate.py
@@ -32,7 +32,7 @@ def consolidate(collection, **kwargs):
     for dset in collection:
         consolidated = dset_to_filepaths(dset, force=True)
 
-        if "time" in kwargs:
+        try:
             time = kwargs["time"].asdict()
 
             file_paths = consolidated
@@ -68,6 +68,10 @@ def consolidate(collection, **kwargs):
             if len(files_in_range) == 0:
                 raise Exception(f"No files found in given time range for {dset}")
 
-        filtered_refs[dset] = consolidated
+        except AttributeError:
+            pass
+
+        finally:
+            filtered_refs[dset] = consolidated
 
     return filtered_refs

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -322,3 +322,18 @@ def test_start_time_is_none(tmpdir):
         "%Y-%m-%d"
     ) == ds.time.values.min().strftime("%Y-%m-%d")
     assert ds_subset.time.values.max().strftime("%Y-%m-%d") == "2120-12-16"
+
+
+@pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
+def test_time_invariant_subset_standard_name(tmpdir):
+    dset = "CMIP6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp119.r1i1p1f1.fx.mrsofc.gr.v20190410"
+
+    result = subset(
+        dset,
+        area=(5.0, 10.0, 20.0, 65.0),
+        output_dir=tmpdir,
+        output_type="nc",
+        file_namer="standard",
+    )
+
+    assert "mrsofc_fx_IPSL-CM6A-LR_ssp119_r1i1p1f1_gr.nc" in result.file_uris[0]

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -324,7 +324,6 @@ def test_start_time_is_none(tmpdir):
     assert ds_subset.time.values.max().strftime("%Y-%m-%d") == "2120-12-16"
 
 
-@pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
 def test_time_invariant_subset_standard_name(tmpdir):
     dset = "CMIP6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp119.r1i1p1f1.fx.mrsofc.gr.v20190410"
 


### PR DESCRIPTION
Changes to allow datasets without a time dimension to be processed.
Adds a test to check this.
Works with changes made to file name template in the equivalent `clisops` and `roocs-utils` branches (`test_time_invariant_datasets` and `time_invariant_datasets`)