### PR TITLE
Replace mini esgf data submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/mini-esgf-data"]
-	path = tests/mini-esgf-data
-	url = https://github.com/roocs/mini-esgf-data.git

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,12 +36,6 @@ You can either clone the public repository:
 
     $ git clone git://github.com/roocs/daops
 
-Get the submodules with test data:
-
-.. code-block:: console
-
-   $ git submodule update --init
-
 Create Conda environment named `daops`:
 
 .. code-block:: console

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ ignore =
 test = pytest
 
 [tool:pytest]
-addopts = --verbose tests/
+addopts = --verbose
 filterwarnings = 
 	ignore::UserWarning
 markers = 

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,11 +1,15 @@
 import os
 import tempfile
+from pathlib import Path
 
 from jinja2 import Template
 
 TESTS_HOME = os.path.abspath(os.path.dirname(__file__))
 TESTS_OUTPUTS = os.path.join(TESTS_HOME, "_outputs")
 ROOCS_CFG = os.path.join(tempfile.gettempdir(), "roocs.ini")
+
+MINI_ESGF_CACHE_DIR = Path.home() / ".mini-esgf-data"
+MINI_ESGF_MASTER_DIR = os.path.join(MINI_ESGF_CACHE_DIR, "master")
 
 try:
     os.mkdir(TESTS_OUTPUTS)
@@ -16,25 +20,26 @@ except Exception:
 def write_roocs_cfg():
     cfg_templ = """
     [project:cmip5]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip5/data/cmip5
+    base_dir = {{ base_dir }}/test_data/badc/cmip5/data/cmip5
 
     [project:cmip6]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip6/data/CMIP6
+    base_dir = {{ base_dir }}/test_data/badc/cmip6/data/CMIP6
 
     [project:cordex]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cordex/data/cordex
+    base_dir = {{ base_dir }}/test_data/badc/cordex/data/cordex
 
     [project:c3s-cmip5]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
+    base_dir = {{ base_dir }}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
 
     [project:c3s-cmip6]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip6/data/CMIP6
+    base_dir = {{ base_dir }}/test_data/badc/cmip6/data/CMIP6
 
     [project:c3s-cordex]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
+    base_dir = {{ base_dir }}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
     """
-    cfg = Template(cfg_templ).render(base_dir=TESTS_HOME)
+    cfg = Template(cfg_templ).render(base_dir=MINI_ESGF_MASTER_DIR)
     with open(ROOCS_CFG, "w") as fp:
         fp.write(cfg)
+
     # point to roocs cfg in environment
     os.environ["ROOCS_CONFIG"] = ROOCS_CFG

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,37 @@
-from tests._common import write_roocs_cfg
+import os
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from tests._common import MINI_ESGF_CACHE_DIR, write_roocs_cfg, MINI_ESGF_MASTER_DIR
 
 write_roocs_cfg()
+
+ESGF_TEST_DATA_REPO_URL = "https://github.com/roocs/mini-esgf-data"
+
+
+@pytest.fixture
+def tmp_netcdf_filename(tmp_path):
+    return tmp_path.joinpath("testfile.nc")
+
+
+# Fixture to load mini-esgf-data repository used by roocs tests
+@pytest.fixture
+def load_esgf_test_data():
+    """
+    This fixture ensures that the required test data repository
+    has been cloned to the cache directory within the home directory.
+    """
+    tmp_repo = "/tmp/.mini-esgf-data"
+    test_data_dir = os.path.join(tmp_repo, "test_data")
+
+    if not os.path.isdir(MINI_ESGF_MASTER_DIR):
+
+        os.makedirs(MINI_ESGF_MASTER_DIR)
+        os.system(f"git clone {ESGF_TEST_DATA_REPO_URL} {tmp_repo}")
+
+        shutil.move(test_data_dir, MINI_ESGF_MASTER_DIR)
+        shutil.rmtree(tmp_repo)

--- a/tests/test_data_utils/test_coord_utils.py
+++ b/tests/test_data_utils/test_coord_utils.py
@@ -2,15 +2,18 @@ import xarray as xr
 
 from daops.data_utils.coord_utils import add_scalar_coord
 
+from tests._common import MINI_ESGF_MASTER_DIR
 
-def test_add_scalar_coord():
+
+def test_add_scalar_coord(load_esgf_test_data):
+
     ds_no_height = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
         combine="by_coords",
         use_cftime=True,
     )
     ds_with_height = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/historical/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/historical/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
         combine="by_coords",
         use_cftime=True,
     )

--- a/tests/test_func_chainer.py
+++ b/tests/test_func_chainer.py
@@ -6,6 +6,8 @@ import xarray as xr
 from daops import utils
 from daops.utils.fixer import FuncChainer
 
+from tests._common import MINI_ESGF_MASTER_DIR
+
 CMIP5_IDS = [
     "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     "cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas",
@@ -17,14 +19,14 @@ CMIP5_IDS = [
 def setup_module(module):
     utils.fixer.Fixer.FIX_DIR = "tests/test_fixes"
     module.CMIP5_FPATHS = [
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
     ]
 
 
 @pytest.mark.skip(reason="Look up of fixes has changed")
-def test_pre_and_post_process_fix():
+def test_pre_and_post_process_fix(load_esgf_test_data):
     ds_test = xr.open_mfdataset(CMIP5_FPATHS[1])
     ds_test["tas"].data = ds_test["tas"].data * 2
     ds_test["tas"].data = ds_test["tas"].data + 100
@@ -33,7 +35,7 @@ def test_pre_and_post_process_fix():
 
 
 @pytest.mark.skip(reason="Look up of fixes has changed")
-def test_post_process_fix_only():
+def test_post_process_fix_only(load_esgf_test_data):
     ds_test = xr.open_mfdataset(CMIP5_FPATHS[0])
     ds_test["zostoga"].attrs["units"] = "s"
     ds_test["zostoga"].attrs["long_name"] = "silly"
@@ -43,7 +45,7 @@ def test_post_process_fix_only():
 
 
 @pytest.mark.skip(reason="Look up of fixes has changed")
-def test_pre_process_fix_only():
+def test_pre_process_fix_only(load_esgf_test_data):
     ds = xr.open_mfdataset(CMIP5_FPATHS[2])
     ds_test = ds.rename({"lat": "silly_lat"})
     ds_code = utils.core.open_dataset(CMIP5_IDS[2], CMIP5_FPATHS[2])

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -11,6 +11,8 @@ from roocs_utils.parameter import time_parameter
 from daops import CONFIG
 from daops.ops.subset import subset
 
+from tests._common import MINI_ESGF_MASTER_DIR
+
 CMIP5_IDS = [
     "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     "cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas",
@@ -34,7 +36,7 @@ def _check_output_nc(result, fname="output_001.nc"):
 
 
 @pytest.mark.online
-def test_subset_zostoga_with_fix(tmpdir):
+def test_subset_zostoga_with_fix(tmpdir, load_esgf_test_data):
 
     result = subset(
         CMIP5_IDS[0],
@@ -42,13 +44,14 @@ def test_subset_zostoga_with_fix(tmpdir):
         output_dir=tmpdir,
         file_namer="simple",
     )
+
     _check_output_nc(result)
     ds = xr.open_dataset(result.file_uris[0], use_cftime=True)
     assert ds.time.shape == (192,)
     assert "lev" not in ds.dims
 
 
-def test_subset_zostoga_with_apply_fixes_false(tmpdir):
+def test_subset_zostoga_with_apply_fixes_false(tmpdir, load_esgf_test_data):
 
     result = subset(
         CMIP5_IDS[0],
@@ -66,7 +69,7 @@ def test_subset_zostoga_with_apply_fixes_false(tmpdir):
 
 
 @pytest.mark.online
-def test_subset_t(tmpdir):
+def test_subset_t(tmpdir, load_esgf_test_data):
     result = subset(
         CMIP5_IDS[1],
         time=("2085-01-16", "2120-12-16"),
@@ -109,10 +112,13 @@ def test_subset_collection_as_empty_string(tmpdir):
 
 
 @pytest.mark.online
-def test_subset_t_y_x(tmpdir):
-    ds = xr.open_mfdataset(
-        f"tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
-        f"atmos/Amon/r1i1p1/latest/tas/*.nc",
+def test_subset_t_y_x(tmpdir, load_esgf_test_data):
+
+    fpath = (f"{MINI_ESGF_MASTER_DIR}/"
+             "test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
+             "atmos/Amon/r1i1p1/latest/tas/*.nc")
+
+    ds = xr.open_mfdataset(fpath,
         use_cftime=True,
         combine="by_coords",
     )
@@ -132,11 +138,14 @@ def test_subset_t_y_x(tmpdir):
 
 
 @pytest.mark.online
-def test_subset_t_z_y_x(tmpdir):
-    ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/NOAA-GFDL/"
-        "GFDL-ESM4/historical/r1i1p1f1/Amon/o3/gr1/v20190726/"
-        "o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc",
+def test_subset_t_z_y_x(tmpdir, load_esgf_test_data):
+
+    fpath = (f"{MINI_ESGF_MASTER_DIR}/"
+              "test_data/badc/cmip6/data/CMIP6/CMIP/NOAA-GFDL/"
+              "GFDL-ESM4/historical/r1i1p1f1/Amon/o3/gr1/v20190726/"
+              "o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc")
+
+    ds = xr.open_mfdataset(fpath,
         use_cftime=True,
         combine="by_coords",
     )
@@ -178,7 +187,7 @@ def test_subset_t_z_y_x(tmpdir):
 
 
 @pytest.mark.online
-def test_subset_t_with_invalid_date(tmpdir):
+def test_subset_t_with_invalid_date(tmpdir, load_esgf_test_data):
     with pytest.raises(Exception) as exc:
         subset(
             CMIP5_IDS[1],
@@ -226,7 +235,7 @@ def test_subset_with_fix_and_multiple_ids(zostoga_id, tmpdir):
 
 
 @pytest.mark.online
-def test_parameter_classes_as_args(tmpdir):
+def test_parameter_classes_as_args(tmpdir, load_esgf_test_data):
     collection = collection_parameter.CollectionParameter(CMIP5_IDS[1])
     time = time_parameter.TimeParameter(("2085-01-16", "2120-12-16"))
     area = area_parameter.AreaParameter((0, -10, 120, 40))
@@ -241,7 +250,7 @@ def test_parameter_classes_as_args(tmpdir):
 
 
 @pytest.mark.online
-def test_time_is_none(tmpdir):
+def test_time_is_none(tmpdir, load_esgf_test_data):
 
     result = subset(
         CMIP5_IDS[1],
@@ -271,7 +280,7 @@ def test_time_is_none(tmpdir):
 
 
 @pytest.mark.online
-def test_end_time_is_none(tmpdir):
+def test_end_time_is_none(tmpdir, load_esgf_test_data):
 
     result = subset(
         CMIP5_IDS[2],
@@ -298,7 +307,7 @@ def test_end_time_is_none(tmpdir):
 
 
 @pytest.mark.online
-def test_start_time_is_none(tmpdir):
+def test_start_time_is_none(tmpdir, load_esgf_test_data):
 
     result = subset(
         CMIP5_IDS[1],
@@ -324,7 +333,7 @@ def test_start_time_is_none(tmpdir):
     assert ds_subset.time.values.max().strftime("%Y-%m-%d") == "2120-12-16"
 
 
-def test_time_invariant_subset_standard_name(tmpdir):
+def test_time_invariant_subset_standard_name(tmpdir, load_esgf_test_data):
     dset = "CMIP6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp119.r1i1p1f1.fx.mrsofc.gr.v20190410"
 
     result = subset(

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -114,11 +114,14 @@ def test_subset_collection_as_empty_string(tmpdir):
 @pytest.mark.online
 def test_subset_t_y_x(tmpdir, load_esgf_test_data):
 
-    fpath = (f"{MINI_ESGF_MASTER_DIR}/"
-             "test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
-             "atmos/Amon/r1i1p1/latest/tas/*.nc")
+    fpath = (
+        f"{MINI_ESGF_MASTER_DIR}/"
+        "test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
+        "atmos/Amon/r1i1p1/latest/tas/*.nc"
+    )
 
-    ds = xr.open_mfdataset(fpath,
+    ds = xr.open_mfdataset(
+        fpath,
         use_cftime=True,
         combine="by_coords",
     )
@@ -140,12 +143,15 @@ def test_subset_t_y_x(tmpdir, load_esgf_test_data):
 @pytest.mark.online
 def test_subset_t_z_y_x(tmpdir, load_esgf_test_data):
 
-    fpath = (f"{MINI_ESGF_MASTER_DIR}/"
-              "test_data/badc/cmip6/data/CMIP6/CMIP/NOAA-GFDL/"
-              "GFDL-ESM4/historical/r1i1p1f1/Amon/o3/gr1/v20190726/"
-              "o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc")
+    fpath = (
+        f"{MINI_ESGF_MASTER_DIR}/"
+        "test_data/badc/cmip6/data/CMIP6/CMIP/NOAA-GFDL/"
+        "GFDL-ESM4/historical/r1i1p1f1/Amon/o3/gr1/v20190726/"
+        "o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc"
+    )
 
-    ds = xr.open_mfdataset(fpath,
+    ds = xr.open_mfdataset(
+        fpath,
         use_cftime=True,
         combine="by_coords",
     )

--- a/tests/test_utils/test_core.py
+++ b/tests/test_utils/test_core.py
@@ -4,14 +4,16 @@ import xarray as xr
 from daops.utils.core import Characterised
 from daops.utils.core import open_dataset
 
+from tests._common import MINI_ESGF_MASTER_DIR
+
 fpath = (
-    "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4"
+    f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4"
     "/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc"
 )
 ds_id = "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
 
 
-def test_open_dataset_with_fix():
+def test_open_dataset_with_fix(load_esgf_test_data):
     unfixed_ds = xr.open_mfdataset(fpath, use_cftime=True, combine="by_coords")
     fixed_ds = open_dataset(ds_id, fpath)
     assert unfixed_ds.dims != fixed_ds.dims
@@ -19,7 +21,7 @@ def test_open_dataset_with_fix():
     assert "lev" not in fixed_ds.dims
 
 
-def test_open_dataset_without_fix():
+def test_open_dataset_without_fix(load_esgf_test_data):
     ds = xr.open_mfdataset(fpath, use_cftime=True, combine="by_coords")
     not_fixed_ds = open_dataset(ds_id, fpath, apply_fixes=False)
     assert ds.dims == not_fixed_ds.dims

--- a/tests/test_utils/test_normalise.py
+++ b/tests/test_utils/test_normalise.py
@@ -2,8 +2,10 @@ from collections import OrderedDict
 
 from daops.utils.normalise import ResultSet
 
+from tests._common import MINI_ESGF_MASTER_DIR
 
-def test_file_uris_url():
+
+def test_file_uris_url(load_esgf_test_data):
     result = ResultSet()
 
     original_file_urls = OrderedDict(
@@ -29,7 +31,7 @@ def test_file_uris_url():
     ]
 
 
-def test_file_uris_files():
+def test_file_uris_files(load_esgf_test_data):
     result = ResultSet()
 
     file_path = OrderedDict(
@@ -37,7 +39,7 @@ def test_file_uris_files():
             (
                 "CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803",
                 [
-                    "tests/mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/IPSL"
+                    f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip6/data/CMIP6/CMIP/IPSL"
                     "/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803"
                     "/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
                 ],
@@ -48,6 +50,6 @@ def test_file_uris_files():
     for ds_id, file in file_path.items():
         result.add(ds_id, file)
     assert result.file_uris == [
-        "tests/mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical"
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical"
         "/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
     ]

--- a/tests/test_xarray/test_xarray_aggregation.py
+++ b/tests/test_xarray/test_xarray_aggregation.py
@@ -21,13 +21,13 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from .._common import TESTS_OUTPUTS
+from .._common import TESTS_OUTPUTS, MINI_ESGF_MASTER_DIR
 
-test_files = [
-    "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc",
-    "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1_203012-205511.nc",
-    "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1_205512-208011.nc",
-]
+file_base = (f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/"
+              "HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1")
+
+test_files = [file_base + end for end in ("_200512-203011.nc", "_203012-205511.nc",
+    "_205512-208011.nc")]
 
 F1, F2, F3 = test_files
 
@@ -84,13 +84,13 @@ def _open(file_paths):
     return xr.open_mfdataset(file_paths, use_cftime=True, combine="by_coords")
 
 
-def test_agg_success_with_no_changes():
+def test_agg_success_with_no_changes(load_esgf_test_data):
     ds = _open([F1, F2, F3])
     assert "tas" in ds.variables
     ds.close()
 
 
-def test_agg_fails_diff_var_attrs_change_F2(var_attr):
+def test_agg_fails_diff_var_attrs_change_F2(var_attr, load_esgf_test_data):
     V = "rubbish"
     file_paths = F1, _make_nc_modify_var_attr(F2, "tas", var_attr, V), F3
     ds = _open(file_paths)
@@ -98,7 +98,7 @@ def test_agg_fails_diff_var_attrs_change_F2(var_attr):
     ds.close()
 
 
-def test_agg_fails_diff_var_attrs_change_F1(var_attr):
+def test_agg_fails_diff_var_attrs_change_F1(var_attr, load_esgf_test_data):
     V = "rubbish"
     file_paths = _make_nc_modify_var_attr(F1, "tas", var_attr, V), F2, F3
     ds = _open(file_paths)
@@ -125,7 +125,7 @@ def test_agg_fails_diff_var_attrs_change_F1(var_attr):
 #         )
 
 
-def test_agg_behaviour_diff_global_attrs_change_F2(global_attr):
+def test_agg_behaviour_diff_global_attrs_change_F2(global_attr, load_esgf_test_data):
     V = "other"
     file_paths = F1, _make_nc_modify_global_attr(F2, global_attr, V), F3
     ds = _open(file_paths)
@@ -133,7 +133,7 @@ def test_agg_behaviour_diff_global_attrs_change_F2(global_attr):
     ds.close()
 
 
-def test_agg_behaviour_diff_global_attrs_change_F1(global_attr):
+def test_agg_behaviour_diff_global_attrs_change_F1(global_attr, load_esgf_test_data):
     V = "other"
     file_paths = _make_nc_modify_global_attr(F1, global_attr, V), F2, F3
     ds = _open(file_paths)
@@ -162,7 +162,7 @@ def test_agg_behaviour_diff_global_attrs_change_F1(global_attr):
 # both new_var_id and old_var_id are in ds.variables no matter which file is changed
 
 
-def test_agg_fails_diff_var_id_change_F1():
+def test_agg_fails_diff_var_id_change_F1(load_esgf_test_data):
     new_var_id = "blah"
     old_var_id = "tas"
     file_paths = _make_nc_modify_var_id(F1, old_var_id, new_var_id), F2, F3
@@ -171,7 +171,7 @@ def test_agg_fails_diff_var_id_change_F1():
     ds.close()
 
 
-def test_agg_fails_diff_var_id_change_F2():
+def test_agg_fails_diff_var_id_change_F2(load_esgf_test_data):
     new_var_id = "blah"
     old_var_id = "tas"
     file_paths = F1, _make_nc_modify_var_id(F2, old_var_id, new_var_id), F3
@@ -180,7 +180,7 @@ def test_agg_fails_diff_var_id_change_F2():
     ds.close()
 
 
-def test_agg_fails_diff_fill_value_change_F2():
+def test_agg_fails_diff_fill_value_change_F2(load_esgf_test_data):
     var_id = "tas"
     fill_value = np.float32(-1e20)
     file_paths = F1, _make_nc_modify_fill_value(F2, var_id, fill_value=fill_value), F3
@@ -189,7 +189,7 @@ def test_agg_fails_diff_fill_value_change_F2():
     ds.close()
 
 
-def test_agg_fails_diff_fill_value_change_F1():
+def test_agg_fails_diff_fill_value_change_F1(load_esgf_test_data):
     var_id = "tas"
     fill_value = np.float32(-1e20)
     file_paths = _make_nc_modify_fill_value(F1, var_id, fill_value=fill_value), F2, F3
@@ -198,7 +198,7 @@ def test_agg_fails_diff_fill_value_change_F1():
     ds.close()
 
 
-def test_agg_affected_by_order():
+def test_agg_affected_by_order(load_esgf_test_data):
     # Apply a breaking change to different files in the sequence and
     # assert that the same exception is raised regardless of which
     # file is modified

--- a/tests/test_xarray/test_xarray_aggregation.py
+++ b/tests/test_xarray/test_xarray_aggregation.py
@@ -23,11 +23,15 @@ import xarray as xr
 
 from .._common import TESTS_OUTPUTS, MINI_ESGF_MASTER_DIR
 
-file_base = (f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/"
-              "HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1")
+file_base = (
+    f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/"
+    "HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1"
+)
 
-test_files = [file_base + end for end in ("_200512-203011.nc", "_203012-205511.nc",
-    "_205512-208011.nc")]
+test_files = [
+    file_base + end
+    for end in ("_200512-203011.nc", "_203012-205511.nc", "_205512-208011.nc")
+]
 
 F1, F2, F3 = test_files
 


### PR DESCRIPTION
@ellesmith88 please review and accept this PR when happy.

I have removed the submodule and replaced it with a fixture that clones the entire mini-esgf-data repo (as with roocs-utils and clisops).

Please double-check I have done everything required to remove reference to the submodule. Thanks