### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ dask[complete]
 netcdf4
 elasticsearch>=7.8.0
 # clisops>=0.4.0
+clisops @ git+https://github.com/roocs/clisops.git
 # roocs-utils>=0.1.5
+roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ setup(
     python_requires=">=3.6.0",
     install_requires=[
         requirements,
-        "roocs-utils @ git+https://github.com/roocs/roocs-utils.git",
-        "clisops @ git+https://github.com/roocs/clisops.git",
     ],
     long_description=_long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
This PR is a quick-fix for the requirements according to PR https://github.com/roocs/clisops/pull/122. `pip` install fails due to different versions of `roocs_utils`. 