### PR TITLE
Gitpython testdata fix

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ pytest==3.8.2
 pytest-runner==4.2
 black
 pre-commit
+GitPython==3.1.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import os
 import shutil
 
+from git import Repo
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 
-from tests._common import MINI_ESGF_CACHE_DIR, write_roocs_cfg, MINI_ESGF_MASTER_DIR
+from tests._common import MINI_ESGF_CACHE_DIR, write_roocs_cfg
 
 write_roocs_cfg()
 
@@ -25,13 +26,17 @@ def load_esgf_test_data():
     This fixture ensures that the required test data repository
     has been cloned to the cache directory within the home directory.
     """
-    tmp_repo = "/tmp/.mini-esgf-data"
-    test_data_dir = os.path.join(tmp_repo, "test_data")
+    branch = "master"
+    target = os.path.join(MINI_ESGF_CACHE_DIR, branch)
 
-    if not os.path.isdir(MINI_ESGF_MASTER_DIR):
+    if not os.path.isdir(MINI_ESGF_CACHE_DIR):
+        os.makedirs(MINI_ESGF_CACHE_DIR)
 
-        os.makedirs(MINI_ESGF_MASTER_DIR)
-        os.system(f"git clone {ESGF_TEST_DATA_REPO_URL} {tmp_repo}")
+    if not os.path.isdir(target):
+        repo = Repo.clone_from(ESGF_TEST_DATA_REPO_URL, target)
+        repo.git.checkout(branch)
 
-        shutil.move(test_data_dir, MINI_ESGF_MASTER_DIR)
-        shutil.rmtree(tmp_repo)
+    if not os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", True) == "FALSE":
+        repo = Repo(target)
+        repo.git.checkout(branch)
+        repo.remotes[0].pull()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def load_esgf_test_data():
         repo = Repo.clone_from(ESGF_TEST_DATA_REPO_URL, target)
         repo.git.checkout(branch)
 
-    if not os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", True) == "FALSE":
+    if os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", "true").lower() != "false":
         repo = Repo(target)
         repo.git.checkout(branch)
         repo.remotes[0].pull()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def load_esgf_test_data():
         repo = Repo.clone_from(ESGF_TEST_DATA_REPO_URL, target)
         repo.git.checkout(branch)
 
-    if os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", "true").lower() != "false":
+    elif os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", "true").lower() != "false":
         repo = Repo(target)
         repo.git.checkout(branch)
         repo.remotes[0].pull()


### PR DESCRIPTION
@ellesmith88: This is a tiny PR - for improving the test-data management - using `gitpython` to clone and update the `mini-esgf-data` cache.