### PR TITLE
change pytest version to >=6.0

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ nbsphinx
 nbconvert
 ipython
 twine==1.12.1
-pytest==3.8.2
+pytest>=6.0
 pytest-runner==4.2
 black
 pre-commit


### PR DESCRIPTION
To work with `clisops`/`xesmf`, flagged by @sol1105 