### PR TITLE
update average test to catch exception when dims is None

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - clisops>=0.6.1
   - elasticsearch>=7.9.1
   - roocs-utils>=0.2.1
-# - pip:
+  - pip:
 #     - roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils
-#     - clisops @ git+https://github.com/roocs/clisops.git@master#egg=clisops
+    - clisops @ git+https://github.com/roocs/clisops.git@master#egg=clisops

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ xarray>=0.15
 dask[complete]
 netcdf4
 elasticsearch>=7.8.0
-clisops>=0.6.1
-# clisops @ git+https://github.com/roocs/clisops.git
+# clisops>=0.6.1
+clisops @ git+https://github.com/roocs/clisops.git
 roocs-utils>=0.2.1
 # roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils

--- a/tests/test_operations/test_average.py
+++ b/tests/test_operations/test_average.py
@@ -64,18 +64,15 @@ def test_average_time_lon(tmpdir):
 
 @pytest.mark.online
 def test_average_none(tmpdir):
-    result = average_over_dims(
-        CMIP5_IDS[1],
-        dims=None,
-        output_dir=tmpdir,
-        file_namer="simple",
-        apply_fixes=False,
-    )
-    _check_output_nc(result)
-    ds = xr.open_dataset(result.file_uris[0], use_cftime=True)
-    assert "time" in ds.dims
-    assert "lon" in ds.dims
-    assert "lat" in ds.dims
+    with pytest.raises(InvalidParameterValue) as exc:
+        average_over_dims(
+            CMIP5_IDS[1],
+            dims=None,
+            output_dir=tmpdir,
+            file_namer="simple",
+            apply_fixes=False,
+        )
+    assert str(exc.value) == "At least one dimension for averaging must be provided"
 
 
 @pytest.mark.online

--- a/tests/test_operations/test_subset.py
+++ b/tests/test_operations/test_subset.py
@@ -345,7 +345,7 @@ def test_time_invariant_subset_standard_name(tmpdir, load_esgf_test_data):
 
     result = subset(
         dset,
-        area=(5.0, 10.0, 20.0, 65.0),
+        area=(5.0, 10.0, 300.0, 80.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="standard",


### PR DESCRIPTION
Update average test where dims=None to catch exception raised which will be implemented by https://github.com/roocs/clisops/pull/162

Temporarily use master branch of `clisops`