### PR TITLE
add fix for EC-Earth further_info_url

### DIFF
--- a/daops/fix_utils/decadal_utils.py
+++ b/daops/fix_utils/decadal_utils.py
@@ -125,7 +125,7 @@ def fix_further_info_url(ds_id, ds):
     model = ds_id.split(".")[3]
     further_info_url = ds.attrs.get("further_info_url", None)
 
-    if model == "EC-Earth3" and "none" in further_info_url:
+    if "none" in further_info_url:
         year = get_sub_experiment_id(ds_id, ds)[:-2]
         return further_info_url.replace("none", year)
 

--- a/daops/fix_utils/decadal_utils.py
+++ b/daops/fix_utils/decadal_utils.py
@@ -119,3 +119,15 @@ def get_decadal_model_attr_from_dict(ds_id, ds, attr):
     model = ds_id.split(".")[3]
     value = model_specific_global_attrs[model][attr]
     return value
+
+
+def fix_further_info_url(ds_id, ds):
+    model = ds_id.split(".")[3]
+    further_info_url = ds.attrs.get("further_info_url", None)
+
+    if model == "EC-Earth3" and "none" in further_info_url:
+        year = get_sub_experiment_id(ds_id, ds)[:-2]
+        return further_info_url.replace("none", year)
+
+    else:
+        return further_info_url

--- a/tests/test_fixes_applied.py
+++ b/tests/test_fixes_applied.py
@@ -49,6 +49,12 @@ def test_fixes_applied_decadal_MOHC_mon(tmpdir, load_esgf_test_data):
     assert ds.startdate == "s200411"
     assert ds.sub_experiment_id == "s200411"
 
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-MM.dcppA-hindcast.s2004.r3i1p1f2"
+    )
+
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
     assert ds.reftime.dims == ()
@@ -127,6 +133,12 @@ def test_fixes_applied_decadal_MOHC_day(tmpdir, load_esgf_test_data):
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
 
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-MM.dcppA-hindcast.s1960.r2i1p1f2"
+    )
+
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
     assert ds.reftime.dims == ()
@@ -203,6 +215,12 @@ def test_fixes_applied_decadal_EC_Earth_mon(tmpdir, load_esgf_test_data):
     )
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
+
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1960.r6i2p1f1"
+    )
 
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
@@ -281,6 +299,12 @@ def test_fixes_applied_decadal_EC_Earth_day(tmpdir, load_esgf_test_data):
     assert ds.startdate == "s196111"
     assert ds.sub_experiment_id == "s196111"
 
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1961.r6i2p1f1"
+    )
+
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
     assert ds.reftime.dims == ()
@@ -293,6 +317,89 @@ def test_fixes_applied_decadal_EC_Earth_day(tmpdir, load_esgf_test_data):
     assert ds.leadtime.dims == ("time",)
     assert ds.leadtime.values[0] == 0.0
     assert ds.leadtime.values[-1] == 425.0
+    assert ds.leadtime.units == "days"
+    assert ds.leadtime.long_name == "Time elapsed since the start of the forecast"
+    assert ds.leadtime.standard_name == "forecast_period"
+
+    # check AddDataVarFix is applied
+    assert "realization" in ds.data_vars
+    assert ds.realization.values == np.array(1, dtype=np.int32)
+    assert (
+        ds.realization.comment
+        == "For more information on the ripf, refer to the variant_label, initialization_description, physics_description and forcing_description global attributes"
+    )
+
+    # check RemoveFillValuesFix is applied
+    # assert no fill value for coordinate variables
+    assert ds.lon.encoding.get("_FillValue") is None
+    assert ds.lat.encoding.get("_FillValue") is None
+    assert ds.time.encoding.get("_FillValue") is None
+
+    # compare to e.g. lon_bnds where the fill value is added by xarray but we haven't removed it
+    assert math.isnan(ds.lon_bnds.encoding.get("_FillValue"))
+
+    # check coordinate attribute removed from realization and bounds variables
+    assert ds.realization.encoding.get("coordinates") is None
+    assert ds.lon_bnds.encoding.get("coordinates") is None
+    assert ds.lat_bnds.encoding.get("coordinates") is None
+    assert ds.time_bnds.encoding.get("coordinates") is None
+
+    # change fix index back
+    CONFIG["elasticsearch"]["fix_store"] = fix_index
+
+
+@pytest.mark.online
+def test_fixes_applied_decadal_EC_Earth_url_fix(tmpdir, load_esgf_test_data):
+    # change fix index to test index which holds these decadal fixes
+    fix_index = CONFIG["elasticsearch"]["fix_store"]
+    test_fix_index = "c3s-roocs-fix-for-tests"
+    CONFIG["elasticsearch"]["fix_store"] = test_fix_index
+
+    # don't use catalog - decadal datasets not in current catalog
+    CONFIG["project:c3s-cmip6"]["use_catalog"] = False
+
+    result = subset(
+        "c3s-cmip6.DCPP.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1960-r2i1p1f1.Amon.tas.gr.v20201215",
+        output_dir=tmpdir,
+        file_namer="simple",
+    )
+
+    _check_output_nc(result)
+    ds = xr.open_dataset(result.file_uris[0], use_cftime=True, decode_timedelta=False)
+    # check VarAttrFix is applied
+    assert ds.time.long_name == "valid_time"
+
+    # check GlobalAttrFix is applied
+    assert ds.forcing_description == "f1, CMIP6 historical forcings"
+    assert (
+        ds.initialization_description
+        == "Atmosphere initialization based on full-fields from ERA-Interim (s1979-s2018) or ERA-40 (s1960-s1978); ocean/sea-ice initialization based on full-fields from NEMO/LIM assimilation run nudged towards ORA-S4 (s1960-s2018)"
+    )
+    assert (
+        ds.physics_description
+        == "physics from the standard model configuration, with no additional tuning or different parametrization"
+    )
+    assert ds.startdate == "s196011"
+    assert ds.sub_experiment_id == "s196011"
+
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1960.r2i1p1f1"
+    )
+
+    # check AddScalarCoord Fix is applied
+    assert "reftime" in ds.coords
+    assert ds.reftime.dims == ()
+    assert ds.reftime.values == np.array(
+        cftime.DatetimeGregorian(1960, 11, 1, 0, 0, 0, 0), dtype=object
+    )
+
+    # check AddCoordFix is applied
+    assert "leadtime" in ds.coords
+    assert ds.leadtime.dims == ("time",)
+    assert ds.leadtime.values[0] == 15.0
+    assert ds.leadtime.values[-1] == 714.0
     assert ds.leadtime.units == "days"
     assert ds.leadtime.long_name == "Time elapsed since the start of the forecast"
     assert ds.leadtime.standard_name == "forecast_period"
@@ -358,6 +465,12 @@ def test_fixes_applied_decadal_MPI_M_mon(tmpdir, load_esgf_test_data):
     )
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
+
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.MPI-M.MPI-ESM1-2-HR.dcppA-hindcast.s1960.r10i1p1f1"
+    )
 
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
@@ -437,6 +550,12 @@ def test_fixes_applied_decadal_MPI_M_day(tmpdir, load_esgf_test_data):
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
 
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.MPI-M.MPI-ESM1-2-HR.dcppA-hindcast.s1960.r2i1p1f1"
+    )
+
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
     assert ds.reftime.dims == ()
@@ -515,6 +634,12 @@ def test_fixes_applied_decadal_CMCC_mon(tmpdir, load_esgf_test_data):
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
 
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.CMCC.CMCC-CM2-SR5.dcppA-hindcast.s1960.r10i1p1f1"
+    )
+
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords
     assert ds.reftime.dims == ()
@@ -592,6 +717,12 @@ def test_fixes_applied_decadal_CMCC_day(tmpdir, load_esgf_test_data):
     )
     assert ds.startdate == "s196011"
     assert ds.sub_experiment_id == "s196011"
+
+    # check further info url is unchanged
+    assert (
+        ds.further_info_url
+        == "https://furtherinfo.es-doc.org/CMIP6.CMCC.CMCC-CM2-SR5.dcppA-hindcast.s1960.r1i1p1f1"
+    )
 
     # check AddScalarCoord Fix is applied
     assert "reftime" in ds.coords


### PR DESCRIPTION
For PR https://github.com/roocs/dachar/issues/96

Added a fix for the `further_info_url` attribute. To make this more straightforward, I added a fix that every decadal dataset will use but only EC-Earth3 datasets with `"none"` in the `further_info_url` have this attribute changed. 

This means that all the decadal fixes can be created from the same template.  (Corresponding updated template here: https://github.com/roocs/dachar/blob/decadal_derive/generate_decadal_fix.py) If you think this should be separate I can remove it and add it into the template for the specific datasets only.