### PR TITLE
Updated fix: remove_fill_values()

### DIFF
--- a/daops/data_utils/attr_utils.py
+++ b/daops/data_utils/attr_utils.py
@@ -1,3 +1,5 @@
+import cf_xarray
+
 from roocs_utils.xarray_utils import xarray_utils as xu
 
 from .common_utils import handle_derive_str
@@ -66,6 +68,10 @@ def remove_fill_values(ds_id, ds):
     for coord_id in ds[main_var].dims:
         if ds.coords[coord_id].dims == (coord_id,):
             ds[coord_id].encoding["_FillValue"] = None
+
+        bounds = ds.cf.get_bounds(coord_id)
+        if bounds is not None:
+            bounds.encoding["_FillValue"] = None
 
     return ds
 


### PR DESCRIPTION
Added import of `cf_xarray` and detection of bounds for each
coordinate. And then sets _FillValue to None to avoid writing
bounds with _FillValue to netcdf.

<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->


* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->


* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
