### PR TITLE
Adding AverageShape to daops

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors
 ------------
 
 * Trevor James Smith smith.trevorj@ouranos.ca
+* Charles Gauthier gauthier.charles@ouranos.ca

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,14 @@
 Version History
 ===============
+v0.10.1 (unreleased)
+-------------------
+
+New Features
+^^^^^^^^^^^^
+
+* Add clisops.ops.average_shape to daops.ops.average
+
+
 
 v0.10.0 (2023-11-27)
 -------------------

--- a/daops/ops/average.py
+++ b/daops/ops/average.py
@@ -130,8 +130,8 @@ def average_shape(
 
     Examples
     --------
-    | collection: ("cmip6.ukesm1.r1.gn.tasmax.v20200101",)
-    | dims: ["time", "lat"]
+    | collection: ("cmip6.cmip..cas.fgoals-g3.historical.r1i1p1fi.Amon.tas.gn.v20190818",)
+    | shape: "path_to_shape"
     | ignore_undetected_dims: (-5.,49.,10.,65)
     | output_type: "netcdf"
     | output_dir: "/cache/wps/procs/req0111"

--- a/daops/ops/average.py
+++ b/daops/ops/average.py
@@ -1,4 +1,5 @@
 from clisops.ops.average import average_over_dims as clisops_average_over_dims
+from clisops.ops.average import average_shape as clisops_average_shape
 from clisops.ops.average import average_time as clisops_average_time
 from roocs_utils.parameter import collection_parameter
 from roocs_utils.parameter import dimension_parameter
@@ -7,6 +8,8 @@ from daops.ops.base import Operation
 
 __all__ = [
     "average_over_dims",
+    "average_time",
+    "average_shape"
 ]
 
 
@@ -74,7 +77,71 @@ def average_over_dims(
     """
 
     result_set = Average(**locals()).calculate()
+    return result_set
 
+
+class AverageShape(Operation):
+    def _resolve_params(self, collection, **params):
+        """
+        Resolve the input parameters to `self.params` and parameterise
+        collection parameter and set to `self.collection`.
+        """
+        shape = params.get("shape")
+        collection = collection_parameter.CollectionParameter(collection)
+
+        self.collection = collection
+        self.params = {
+            "shape": shape,
+            "variable": params.get("variable"),
+        }
+
+    def get_operation_callable(self):
+        return clisops_average_shape
+
+
+def average_shape(
+    collection,
+    shape,
+    variable=None,
+    output_dir=None,
+    output_type="netcdf",
+    split_method="time:auto",
+    file_namer="standard",
+    apply_fixes=True,
+):
+    """
+    Average input dataset over indicated shape.
+
+    Parameters
+    ----------
+    collection: Collection of datasets to process, sequence or string of comma separated dataset identifiers.
+    shape: Path to shape file, or directly a geodataframe to perform average within.
+    variable: Variables to average. If None, average over all data variables.
+    output_dir: str or path like object describing output directory for output files.
+    output_type: {"netcdf", "nc", "zarr", "xarray"}
+    split_method: {"time:auto"}
+    file_namer: {"standard", "simple"}
+    apply_fixes: Boolean. If True fixes will be applied to datasets if needed. Default is True.
+
+    Returns
+    -------
+    List of outputs in the selected type: a list of xarray Datasets or file paths.
+
+
+    Examples
+    --------
+    | collection: ("cmip6.ukesm1.r1.gn.tasmax.v20200101",)
+    | dims: ["time", "lat"]
+    | ignore_undetected_dims: (-5.,49.,10.,65)
+    | output_type: "netcdf"
+    | output_dir: "/cache/wps/procs/req0111"
+    | split_method: "time:auto"
+    | file_namer: "standard"
+    | apply_fixes: True
+
+    """
+    a = AverageShape(**locals())
+    result_set = AverageShape(**locals()).calculate()
     return result_set
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [~] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is related to this [issue](https://github.com/ESGF/esgf-cwt/issues/30) and is the continuation of this [PR](https://github.com/roocs/clisops/pull/312) 
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] HISTORY.rst has been updated (with summary of main changes)
- [X] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
This PR adds the Spatial Averager operator to daops allowing to perform an average over a specified region

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
Not to my knowledge

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
As it is, the `shape` parameter required by `AverageShape` is similar to the freq parameter of `AverageTime` in that it is only defined using the inputed argument. For the averqage across dimensions (`Average`), the `dims` parameter is defined as a `dimension_parameter` coming from `roocs_utils`. I was not sure if it was needed to add a `shape_parameter` to `roocs_utils ` so I left it as is. If you feel like that would be preferable , please mention it in the PR and I'll add a `shape_parameter` to `roocs_utils`.