### PR TITLE
Prepare version 0.13.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,10 +7,10 @@
 - [ ] HISTORY.rst has been updated (with summary of main changes)
 - [ ] I have added my relevant user information to `AUTHORS.md`
 
-* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
+### What kind of change does this PR introduce? <!--(Bug fix, feature, docs update, etc.)-->
 
 
-* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
+### Does this PR introduce a breaking change? <!--(Has there been an API change? New dependencies?)-->
 
 
-* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
+### Other information <!--(Relevant discussion threads? Outside documentation pages?)-->

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 Version History
 ===============
 
-v0.13.0 (unreleased)
+v0.13.0 (2025-02-07)
 --------------------
 
 Breaking Changes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ author = "Elle Smith"
 # the built documents.
 #
 # The short X.Y version.
-version = "0.12.0"
+version = "0.13.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
     {name = "Elle Smith", email = "eleanor.smith@stfc.ac.uk"}
 ]
 maintainers = [
-    {name = "Trevor James Smith", email = "smith.trevorj@ouranos.ca"}
+    {name = "Trevor James Smith", email = "smith.trevorj@ouranos.ca"},
+    {name = "Carsten Ehbrecht", email = "ehbrecht@dkrz.de"}
 ]
 license = {text = "BSD"}
 readme = {file = "README.rst", content-type = "text/x-rst"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.12.0"
+current_version = "0.13.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ target-version = [
 current_version = "0.13.0"
 commit = true
 commit_args = "--no-verify"
-tag = true
+tag = false
 allow_dirty = false
 
 [[tool.bumpversion.files]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.11.0"
+current_version = "0.12.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/src/daops/__init__.py
+++ b/src/daops/__init__.py
@@ -3,7 +3,7 @@
 __author__ = """Elle Smith"""
 __contact__ = "eleanor.smith@stfc.ac.uk"
 __copyright__ = "Copyright 2018-2025 United Kingdom Research and Innovation"
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 from functools import lru_cache
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

Prepares the next minor version for tomorrow (2025-02-07)

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

I've made it so that tagging must happen when pushed to the `main` branch. This behaviour resembles all other projects I actively maintain.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

There were enough significant changes to justify a minor bump, IMO. @cehbrecht, I don't have access to PyPI for this project, so I leave the merge and deployment to you!

The trunk has been renamed `main`. This has been the suggested default for several years now. Open Pull Requests have been updated to point towards it.